### PR TITLE
Lembretes novos do Balonista.

### DIFF
--- a/src/roles.json
+++ b/src/roles.json
@@ -1300,9 +1300,11 @@
     "firstNightReminder": "Choose a character type. Point to a player whose character is of that type. Place the Balloonist's \"Seen\" reminder next to that character.",
     "otherNight": 47,
     "otherNightReminder": "Choose a character type you have not chosen yet. Point to a player whose character is of that type, if there are any. Place the Balloonist's \"Seen\" reminder next to that character.",
-    "reminders": [
-      "Visto"
-    ],
+    "reminders": ["Cidadão Visto",
+        "Forasteiro Visto",
+        "Lacaio Visto",
+        "Demônio Visto",
+        "Viajante Visto"],
     "setup": true,
     "name": "Balonista",
     "team": "townsfolk",


### PR DESCRIPTION
O Balonista precisa de lembretes específicos, caso o tipo de personagem de um jogador mude durante o jogo (por exemplo, Forasteiro escolhido pelo Fang Gu, Cidadão transformado em Forasteiro pela Velha do Fosso), ou caso o Espião ou Recluso sejam lidos falsamente.

Referência: https://github.com/bra1n/townsquare/blob/main/src/roles.json